### PR TITLE
Fix crash when adding spellbook to an inventory

### DIFF
--- a/scripts/spellManager.js
+++ b/scripts/spellManager.js
@@ -95,10 +95,13 @@ const spellExporter = async (actor) => {
     const newItemData = {
         name: newItemName,
         type: "loot",
-        flags: "",
+        flags: {},
+        folder: null,
         img: "systems/dnd5e/icons/items/inventory/book-purple.jpg",
         data: {
-            description: {value: spellBookText}
+            description: {value: spellBookText},
+            weight: 3,
+            price: 50
         }
     }
     if (spellBookText !== '') {


### PR DESCRIPTION
When adding the generated spellbook to an Actor's inventory, the process would crash due to missing the `folder` field, as well as the `flags` field being the incorrect type.

I've also added the default weight and price of a spellbook item.